### PR TITLE
fix: vault token renewal and reauthentication

### DIFF
--- a/pkg/client/vault/vault.go
+++ b/pkg/client/vault/vault.go
@@ -3,15 +3,21 @@ package vault
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	vault "github.com/hashicorp/vault/api"
 	"github.com/spf13/viper"
 
 	"github.com/nimbolus/terraform-backend/internal"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
 	k8sServiceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+var (
+	authTokenMutex sync.Mutex
 )
 
 func NewVaultClient() (*vault.Client, error) {
@@ -33,23 +39,24 @@ func NewVaultClient() (*vault.Client, error) {
 	if token != "" {
 		client.SetToken(token)
 	} else if role := viper.GetString("vault_kube_auth_role"); role != "" {
-		jwt, err := os.ReadFile(k8sServiceAccountFile)
+		secret, err := kubeAuthLogin(client, role)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read k8s service account: %w", err)
+			return nil, err
 		}
 
-		viper.SetDefault("vault_kube_auth_name", "kubernetes")
-		path := fmt.Sprintf("auth/%s/login", viper.GetString("vault_kube_auth_name"))
-		params := map[string]any{
-			"jwt":  string(jwt),
-			"role": role,
-		}
-		secret, err := client.Logical().Write(path, params)
-		if err != nil {
-			return nil, fmt.Errorf("failed to login with k8s service account: %w", err)
-		}
+		go func() {
+			for {
+				if err := authTokenWatcher(client, secret); err != nil {
+					log.Fatal(err.Error())
+				}
 
-		client.SetToken(secret.Auth.ClientToken)
+				secret, err = kubeAuthLogin(client, role)
+				if err != nil {
+					log.Fatal(err.Error())
+				}
+			}
+		}()
+
 	} else {
 		return nil, fmt.Errorf("unable to initialize vault client: no login method found")
 	}
@@ -57,7 +64,58 @@ func NewVaultClient() (*vault.Client, error) {
 	return client, nil
 }
 
+func kubeAuthLogin(client *vault.Client, role string) (*vault.Secret, error) {
+	authTokenMutex.Lock()
+	defer authTokenMutex.Unlock()
+
+	jwt, err := os.ReadFile(k8sServiceAccountFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read k8s service account: %w", err)
+	}
+
+	viper.SetDefault("vault_kube_auth_name", "kubernetes")
+	path := fmt.Sprintf("auth/%s/login", viper.GetString("vault_kube_auth_name"))
+	params := map[string]any{
+		"jwt":  string(jwt),
+		"role": role,
+	}
+
+	log.Infof("log in to vault using k8s service account with role %s", role)
+	secret, err := client.Logical().Write(path, params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to login with k8s service account: %w", err)
+	}
+
+	client.SetToken(secret.Auth.ClientToken)
+	return secret, nil
+}
+
+func authTokenWatcher(client *vault.Client, secret *vault.Secret) error {
+	watcher, err := client.NewLifetimeWatcher(&vault.LifetimeWatcherInput{
+		Secret: secret,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize vault auth token lifetime watcher: %v", err)
+	}
+
+	go watcher.Start()
+	defer watcher.Stop()
+
+	for {
+		select {
+		case info := <-watcher.RenewCh():
+			log.Infof("vault auth token was renewed successfully, remaining lifetime %ds", info.Secret.Auth.LeaseDuration)
+		case _ = <-watcher.DoneCh():
+			log.Warnf("vault auth token could not be renewed, try reauthentication")
+			return nil
+		}
+	}
+}
+
 func GetKvValue(client *vault.Client, path string, value string) (string, error) {
+	authTokenMutex.Lock()
+	defer authTokenMutex.Unlock()
+
 	secret, err := client.Logical().Read(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to get vault secret at %s: %v", path, err)


### PR DESCRIPTION
Hashicorp Vault or OpenBao tokens need to be renewed and, if the max. token lifetime is reached, recreated. To archive this, Vault offers a so called `LifetimeWatcher´ (see [github.com/hashicorp/vault-examples](https://github.com/hashicorp/vault-examples/blob/main/examples/token-renewal/README.md)) which is used here.

For a token TTL of 60s and max. lifetime of 120s, the process looks like this:
```
...
time="2026-01-18T14:46:30Z" level=info msg="log in to vault using k8s service account with role terraform-backend"
...
time="2026-01-18T14:46:30Z" level=info msg="vault auth token was renewed successfully, remaining lifetime 60s"
time="2026-01-18T14:46:38Z" level=info msg="GET /state/example/dummy"
time="2026-01-18T14:47:13Z" level=info msg="vault auth token was renewed successfully, remaining lifetime 60s"
time="2026-01-18T14:47:17Z" level=info msg="GET /state/example/dummy"
time="2026-01-18T14:47:56Z" level=info msg="vault auth token was renewed successfully, remaining lifetime 34s"
time="2026-01-18T14:47:56Z" level=warning msg="vault auth token could not be renewed, try reauthentication"
time="2026-01-18T14:47:56Z" level=info msg="log in to vault using k8s service account with role terraform-backend"
time="2026-01-18T14:47:56Z" level=info msg="vault auth token was renewed successfully, remaining lifetime 60s"
time="2026-01-18T14:48:07Z" level=info msg="GET /state/example/dummy"
```