### PR TITLE
fix: verify lock id on server side during force-unlock if possible

### DIFF
--- a/pkg/lock/locker.go
+++ b/pkg/lock/locker.go
@@ -22,12 +22,19 @@ func NewLockerWithForceUnlockEnabled(l Locker) *LockerWithForceUnlockEnabled {
 }
 
 func (l *LockerWithForceUnlockEnabled) Unlock(state *terraform.State) (bool, error) {
+	lock, err := l.GetLock(state)
+	if err != nil {
+		return false, fmt.Errorf("failed to get lock for force-unlocking: %w", err)
+	}
+
 	if state.Lock.ID == "" {
-		lock, err := l.GetLock(state)
-		if err != nil {
-			return false, fmt.Errorf("failed to get lock for force-unlocking: %w", err)
-		}
+		// terraform doesn't send the lock id and verifies it on client side
 		state.Lock = lock
+	} else {
+		// opentofu does send the lock id, so it's possible to also verify it on server side
+		if state.Lock.ID == lock.ID {
+			state.Lock = lock
+		}
 	}
 
 	return l.Locker.Unlock(state)


### PR DESCRIPTION
OpenTofu sends the lock id provided by the user in the force-unlock request, so it can be verified, but the complete lock info still needs to be loaded from backend.